### PR TITLE
Potential fix for code scanning alert no. 8: Cross-site scripting

### DIFF
--- a/WebGoat/WebGoatCoins/Autocomplete.ashx.cs
+++ b/WebGoat/WebGoatCoins/Autocomplete.ashx.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using System.Net;
 using System.Data;
 using OWASP.WebGoat.NET.App_Code;
 using OWASP.WebGoat.NET.App_Code.DB;
@@ -23,9 +24,10 @@ namespace OWASP.WebGoat.NET.WebGoatCoins
             //context.Response.Write("Hello World");
 
             string query = context.Request["query"];
+            string encodedQuery = System.Net.WebUtility.HtmlEncode(query);
             
-            DataSet ds = du.GetCustomerEmails(query);
-            string json = Encoder.ToJSONSAutocompleteString(query, ds.Tables[0]);
+            DataSet ds = du.GetCustomerEmails(encodedQuery);
+            string json = Encoder.ToJSONSAutocompleteString(encodedQuery, ds.Tables[0]);
 
             if (json != null && json.Length > 0)
             {


### PR DESCRIPTION
Potential fix for [https://github.com/niallpat/demo-csharp/security/code-scanning/8](https://github.com/niallpat/demo-csharp/security/code-scanning/8)

To fix the issue, we need to ensure that any user-provided input is properly sanitized or encoded before being included in the HTTP response. The best way to address this is to use the `System.Net.WebUtility.HtmlEncode` method to encode the `query` parameter before passing it to `Encoder.ToJSONSAutocompleteString`. This ensures that any potentially malicious input is rendered harmless by escaping special characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
